### PR TITLE
this fixes a crash that happens if you press ctrl-o without having a …

### DIFF
--- a/cursive/src/main.rs
+++ b/cursive/src/main.rs
@@ -63,10 +63,20 @@ fn copy(ui: &mut Cursive) -> () {
 }
 
 fn open(ui: &mut Cursive) -> () {
-    let password_entry: pass::PasswordEntry = (*ui
+    let password_entry_option: Option<Option<std::rc::Rc<ripasso::pass::PasswordEntry>>> = ui
         .call_on_id("results", |l: &mut SelectView<pass::PasswordEntry>| {
-            l.selection().unwrap()
-        }).unwrap()).clone();
+            l.selection()
+        });
+
+    let password_entry: pass::PasswordEntry = (*(match password_entry_option {
+        Some(level_1) => {
+            match level_1 {
+                Some(level_2) => level_2,
+                None => return
+            }
+        },
+        None => return
+    })).clone();
 
     let password = password_entry.secret().unwrap();
     let d =


### PR DESCRIPTION
…secret selected, for example when the program first starts