### PR TITLE
Implement xkcd password

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,6 +1340,7 @@ dependencies = [
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xkcd-password 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1697,6 +1698,14 @@ name = "xi-unicode"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "xkcd-password"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum arc-swap 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1507f9b80b3ef096751728cf3f43bb0111ec906e44f5d8587e02c10643b9a2cd"
@@ -1885,3 +1894,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum x11-clipboard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "89bd49c06c9eb5d98e6ba6536cf64ac9f7ee3a009b2f53996d405b3944f6bcea"
 "checksum xcb 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
 "checksum xi-unicode 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12ea8eda4b1eb72f02d148402e23832d56a33f55d8c1b2d5bcdde91d79d47cb1"
+"checksum xkcd-password 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0da567acde19c6f413d2512b6fff48496fc709c1adf22625f90e7a6c09ff57f8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4.5"
 env_logger = "0.6"
 dirs = "1.0"
 rand = "0.7"
+xkcd-password = "0.1.1"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/cursive/src/main.rs
+++ b/cursive/src/main.rs
@@ -149,7 +149,7 @@ fn open(ui: &mut Cursive) -> () {
                 }
             })
             .button("Generate", move |s| {
-                let new_password = ripasso::pass::generate_password(24);
+                let new_password = ripasso::pass::generate_password(4);
                 s.call_on_id("editbox", |e: &mut TextArea| {
                     e.set_content(new_password);
                 });

--- a/src/pass.rs
+++ b/src/pass.rs
@@ -24,9 +24,9 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
 use std::time::Duration;
 
-extern crate rand;
-use pass::rand::{thread_rng, Rng};
-use pass::rand::distributions::Alphanumeric;
+extern crate xkcd_password;
+use self::xkcd_password::Dictionary::en_US as Dictionary;
+use self::xkcd_password::generate_password as GeneratePassword;
 
 use chrono::prelude::*;
 use git2;
@@ -545,10 +545,7 @@ pub fn watch() -> Result<(Receiver<PasswordEvent>, PasswordList)> {
 }
 
 pub fn generate_password(length: usize) -> String {
-    return thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(length)
-        .collect();
+    return GeneratePassword(length, Dictionary);
 }
 
 fn to_name(base: &path::PathBuf, path: &path::PathBuf) -> String {


### PR DESCRIPTION
As commented in #40 we can change the default password generator to a passphrase generator based in the default en_US dictionary (included with the crate xkcd_password)

![ripasso](https://user-images.githubusercontent.com/1911813/63884851-9f86bf00-c99c-11e9-8eb5-b70492667d6f.gif)

Please review code styles. I'm new in rust.