### PR TITLE
update Cargo.lock to include ripasso-* version numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "ripasso"
-version = "0.0.1"
+version = "0.3.0-alpha"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1354,37 +1354,37 @@ dependencies = [
 
 [[package]]
 name = "ripasso-cursive"
-version = "0.1.0"
+version = "0.3.0-alpha"
 dependencies = [
  "clipboard 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cursive 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ripasso 0.0.1",
+ "ripasso 0.3.0-alpha",
 ]
 
 [[package]]
 name = "ripasso-gtk"
-version = "0.1.0"
+version = "0.3.0-alpha"
 dependencies = [
  "glib 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gtk 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ripasso 0.0.1",
+ "ripasso 0.3.0-alpha",
 ]
 
 [[package]]
 name = "ripasso-man"
-version = "0.1.0"
+version = "0.3.0-alpha"
 dependencies = [
  "man 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ripasso-qt"
-version = "0.1.0"
+version = "0.3.0-alpha"
 dependencies = [
  "clipboard 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "qml 0.0.9 (git+https://github.com/White-Oak/qml-rust)",
- "ripasso 0.0.1",
+ "ripasso 0.3.0-alpha",
 ]
 
 [[package]]


### PR DESCRIPTION
.. this is so it builds with --frozen