### PR TITLE
fix shortcut typo

### DIFF
--- a/cursive/res/sv.po
+++ b/cursive/res/sv.po
@@ -82,7 +82,7 @@ msgstr "Kopiera (ctrl-y)"
 
 #: cursive/src/main.rs:1493
 msgid "Copy Name (ctrl-u)"
-msgstr "Kopiera Namnet (ctrl-y)"
+msgstr "Kopiera Namnet (ctrl-u)"
 
 #: cursive/src/wizard.rs:77 cursive/src/wizard.rs:102 cursive/src/wizard.rs:146
 msgid "Create"


### PR DESCRIPTION
use same shortcut as an english version does. 

fixes #195 