### PR TITLE
replace yay with paru

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cargo build -p ripasso-gtk
 
 TUI version
 ```
-yay install ripasso-cursive
+paru install ripasso-cursive
 ```
 
 ### Fedora


### PR DESCRIPTION
Paru has replaced yay (main yay dev has switched from yay to paru, see this for more info https://www.linuxfordevices.com/tutorials/linux/paru-arch-linux#Conclusion )