### PR TITLE
Improve the edit/save configuration dialog

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Dependencies
-        run: sudo apt install libgpgme11-dev libgpg-error-dev libgtk-3-dev qtdeclarative5-dev libqt5svg5-dev -y
+        run: sudo apt install libgpgme11-dev libgpg-error-dev libgtk-3-dev qtdeclarative5-dev libqt5svg5-dev libxcb-shape0-dev libxcb-xfixes0-dev -y
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all
 
   fmt:
     name: Rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Dependencies
-        run: sudo apt install libgpgme11-dev libgpg-error-dev -y
+        run: sudo apt install libgpgme11-dev libgpg-error-dev libgtk-3-dev qtdeclarative5-dev libqt5svg5-dev -y
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,6 +2264,7 @@ dependencies = [
  "cursive",
  "gettext",
  "glob",
+ "hex",
  "lazy_static 1.4.0",
  "locale_config",
  "man",

--- a/cursive/Cargo.toml
+++ b/cursive/Cargo.toml
@@ -20,6 +20,7 @@ lazy_static = "1.4.0"
 toml = "0.5.8"
 term_size = "0.3.2"
 wl-clipboard-rs = "0.4.1"
+hex = "0.4.3"
 
 [dependencies.config]
 version = "0.11.0"

--- a/cursive/src/main.rs
+++ b/cursive/src/main.rs
@@ -17,8 +17,8 @@
 
 use cursive::traits::*;
 use cursive::views::{
-    CircularFocus, Dialog, EditView, LinearLayout, NamedView, OnEventView, ResizedView, ScrollView,
-    SelectView, TextArea, TextView, Checkbox,
+    Checkbox, CircularFocus, Dialog, EditView, LinearLayout, NamedView, OnEventView, ResizedView,
+    ScrollView, SelectView, TextArea, TextView,
 };
 
 use cursive::menu::Tree;
@@ -29,7 +29,9 @@ use cursive::direction::Orientation;
 use cursive::event::{Event, Key};
 
 use ripasso::pass;
-use ripasso::pass::{OwnerTrustLevel, PasswordStore, PasswordStoreType, SignatureStatus, all_recipients_from_stores};
+use ripasso::pass::{
+    all_recipients_from_stores, OwnerTrustLevel, PasswordStore, PasswordStoreType, SignatureStatus,
+};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::rc::Rc;
@@ -1088,13 +1090,24 @@ fn save_edit_config(
     let e_k_bool = is_checkbox_checked(ui, "edit_keys_input");
 
     let e_k = if e_k_bool {
-        let mut recipients:Vec<Recipient> = vec![];
-        for (i, r) in all_recipients_from_stores(stores.clone()).unwrap().iter().enumerate() {
-            if is_checkbox_checked(ui, &format!("edit_recipient_{}", i)) && r.fingerprint.is_some() {
+        let mut recipients: Vec<Recipient> = vec![];
+        for (i, r) in all_recipients_from_stores(stores.clone())
+            .unwrap()
+            .iter()
+            .enumerate()
+        {
+            if is_checkbox_checked(ui, &format!("edit_recipient_{}", i)) && r.fingerprint.is_some()
+            {
                 recipients.push(r.clone());
             }
         }
-        Some(recipients.iter().map(|f| hex::encode_upper(f.fingerprint.unwrap())).collect::<Vec<String>>().join(","))
+        Some(
+            recipients
+                .iter()
+                .map(|f| hex::encode_upper(f.fingerprint.unwrap()))
+                .collect::<Vec<String>>()
+                .join(","),
+        )
     } else {
         None
     };
@@ -1135,7 +1148,7 @@ fn save_new_config(
     stores: Arc<Mutex<Vec<PasswordStore>>>,
     config_file_location: &Path,
     home: &Option<PathBuf>,
-    all_recipients: &[Recipient]
+    all_recipients: &[Recipient],
 ) -> Result<()> {
     let e_n = &*get_value_from_input(ui, "new_name_input").unwrap();
     let e_d = &*get_value_from_input(ui, "new_directory_input").unwrap();
@@ -1148,7 +1161,14 @@ fn save_new_config(
         }
     }
 
-    let new_store = PasswordStore::create(e_n, &Some(PathBuf::from(e_d.clone())), &recipients, e_k, home, &None)?;
+    let new_store = PasswordStore::create(
+        e_n,
+        &Some(PathBuf::from(e_d.clone())),
+        &recipients,
+        e_k,
+        home,
+        &None,
+    )?;
 
     {
         let mut stores_borrowed = stores.lock().unwrap();
@@ -1249,16 +1269,12 @@ fn edit_store_in_config(
     fields.add_child(keys_fields);
 
     fields.add_child(
-        TextView::new(CATALOG.gettext("Store Members: "))
-            .fixed_size((30_usize, 1_usize)),
+        TextView::new(CATALOG.gettext("Store Members: ")).fixed_size((30_usize, 1_usize)),
     );
     let store_recipients = store.all_recipients()?;
     for (i, recipient) in all_recipients.iter().enumerate() {
         let mut row = LinearLayout::horizontal();
-        row.add_child(
-            TextView::new(&recipient.name)
-                .fixed_size((30_usize, 1_usize)),
-        );
+        row.add_child(TextView::new(&recipient.name).fixed_size((30_usize, 1_usize)));
         let mut c = Checkbox::new();
         if store_recipients.contains(recipient) {
             c.set_checked(true);
@@ -1375,15 +1391,11 @@ fn add_store_to_config(
     fields.add_child(directory_fields);
     fields.add_child(keys_fields);
     fields.add_child(
-        TextView::new(CATALOG.gettext("Store Members: "))
-            .fixed_size((30_usize, 1_usize)),
+        TextView::new(CATALOG.gettext("Store Members: ")).fixed_size((30_usize, 1_usize)),
     );
     for (i, recipient) in all_recipients.iter().enumerate() {
         let mut row = LinearLayout::horizontal();
-        row.add_child(
-            TextView::new(&recipient.name)
-                .fixed_size((30_usize, 1_usize)),
-        );
+        row.add_child(TextView::new(&recipient.name).fixed_size((30_usize, 1_usize)));
         row.add_child(Checkbox::new().with_name(format!("new_recipient_{}", i)));
         fields.add_child(row);
     }
@@ -1398,7 +1410,13 @@ fn add_store_to_config(
     let d = Dialog::around(fields)
         .title(CATALOG.gettext("New store config"))
         .button(CATALOG.gettext("Save"), move |ui: &mut Cursive| {
-            let res = save_new_config(ui, stores.clone(), &config_file_location, &home, &all_recipients);
+            let res = save_new_config(
+                ui,
+                stores.clone(),
+                &config_file_location,
+                &home,
+                &all_recipients,
+            );
             if let Err(err) = res {
                 helpers::errorbox(ui, &err);
             } else {
@@ -1412,7 +1430,13 @@ fn add_store_to_config(
             s.pop_layer();
         })
         .on_event(Key::Enter, move |ui: &mut Cursive| {
-            let res = save_new_config(ui, stores2.clone(), &config_file_location2, &home2, &all_recipients2);
+            let res = save_new_config(
+                ui,
+                stores2.clone(),
+                &config_file_location2,
+                &home2,
+                &all_recipients2,
+            );
             if let Err(err) = res {
                 helpers::errorbox(ui, &err);
             } else {

--- a/cursive/src/main.rs
+++ b/cursive/src/main.rs
@@ -29,7 +29,7 @@ use cursive::direction::Orientation;
 use cursive::event::{Event, Key};
 
 use ripasso::pass;
-use ripasso::pass::{OwnerTrustLevel, PasswordStore, PasswordStoreType, SignatureStatus};
+use ripasso::pass::{OwnerTrustLevel, PasswordStore, PasswordStoreType, SignatureStatus, all_recipients_from_stores};
 use std::path::{Path, PathBuf};
 use std::process;
 use std::rc::Rc;
@@ -1175,28 +1175,6 @@ fn is_checkbox_checked(ui: &mut Cursive, name: &str) -> bool {
     });
 
     checked
-}
-
-fn all_recipients_from_stores(stores: Arc<Mutex<Vec<PasswordStore>>>) -> Result<Vec<Recipient>> {
-    let all_recipients: Vec<Recipient> = {
-        let mut ar: HashMap<String, Recipient> = HashMap::new();
-        let stores = stores.lock().unwrap();
-        for store in stores.iter() {
-            for recipient in store.all_recipients()? {
-                let key = {
-                    if recipient.fingerprint == None {
-                        recipient.key_id.clone()
-                    } else {
-                        hex::encode_upper(recipient.fingerprint.as_ref().unwrap())
-                    }
-                };
-                ar.insert(key, recipient);
-            }
-        }
-        ar.into_iter().map(|(_id, r)| r).collect()
-    };
-
-    Ok(all_recipients)
 }
 
 fn edit_store_in_config(

--- a/cursive/src/tests/main.rs
+++ b/cursive/src/tests/main.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+
+#[test]
+fn is_checkbox_checked_false() {
+    let mut siv = cursive::default();
+    siv.add_layer(Checkbox::new().with_name("unit_test"));
+
+    assert_eq!(false, is_checkbox_checked(&mut siv, "unit_test"));
+}
+
+#[test]
+fn is_checkbox_checked_true() {
+    let mut siv = cursive::default();
+    let mut c_b = Checkbox::new();
+    c_b.set_checked(true);
+    siv.add_layer(c_b.with_name("unit_test"));
+
+    assert_eq!(true, is_checkbox_checked(&mut siv, "unit_test"));
+}

--- a/cursive/src/tests/main.rs
+++ b/cursive/src/tests/main.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-
 #[test]
 fn is_checkbox_checked_false() {
     let mut siv = cursive::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,12 @@
 
 /// This is the library part that handles all encryption and decryption
 pub mod crypto;
+/// All functions and structs related to error handling
 pub(crate) mod error;
 /// This is the library part of ripasso, it implements the functions needed to manipulate a pass
 /// directory.
 pub mod pass;
+/// All functions and structs related to handling the identity and signing of things
 pub(crate) mod signature;
 /// This is the library that handles password generation, based on the long word list from EFF
 /// https://www.eff.org/sv/deeplinks/2016/07/new-wordlists-random-passphrases

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -318,7 +318,8 @@ impl Recipient {
         Ok(recipients)
     }
 
-    fn write_recipients_file(
+    /// write the .gpg-id.sig file
+    pub fn write_recipients_file(
         recipients: &[Recipient],
         recipients_file: &Path,
         valid_gpg_signing_keys: &[String],

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -66,7 +66,7 @@ pub fn parse_signing_keys(
 }
 
 /// the GPG trust level for a key
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum OwnerTrustLevel {
     /// is only used for your own keys. You trust this key 'per se'. Any message signed with that key,
     /// will be trusted. This is also the reason why any key from a friend, that is signed by you, will
@@ -107,7 +107,7 @@ impl From<&gpgme::Validity> for OwnerTrustLevel {
 }
 
 /// A Recipient can either be in the GPG keyring, or not.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum KeyRingStatus {
     InKeyRing,
     NotInKeyRing,
@@ -136,7 +136,7 @@ impl std::cmp::Eq for IdComment {}
 
 /// Describes a comment around a gpg id / fingerprint. See this commit for source:
 /// https://git.zx2c4.com/password-store/commit/?id=a271b43cbd76cc30406202c49041b552656538bd
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Comment {
     /// The comment field from the .gpg-id file, above the user fingerprint
     /// not including the leading '#' characters.
@@ -149,7 +149,7 @@ pub struct Comment {
 /// Represents one person on the team.
 ///
 /// All secrets are encrypted with the key_id of the recipients.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Recipient {
     /// Human readable name of the person.
     pub name: String,

--- a/src/tests/pass.rs
+++ b/src/tests/pass.rs
@@ -1706,7 +1706,10 @@ fn init_git_repo_success() -> Result<()> {
 fn all_recipients_from_stores_plain() -> Result<()> {
     let td = tempdir()?;
 
-    fs::write(td.path().join(".gpg-id"), "7E068070D5EF794B00C8A9D91D108E6C07CBC406")?;
+    fs::write(
+        td.path().join(".gpg-id"),
+        "7E068070D5EF794B00C8A9D91D108E6C07CBC406",
+    )?;
 
     let s1 = PasswordStore {
         name: "unit test store".to_owned(),

--- a/src/tests/pass.rs
+++ b/src/tests/pass.rs
@@ -1701,3 +1701,26 @@ fn init_git_repo_success() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn all_recipients_from_stores_plain() -> Result<()> {
+    let td = tempdir()?;
+
+    fs::write(td.path().join(".gpg-id"), "7E068070D5EF794B00C8A9D91D108E6C07CBC406")?;
+
+    let s1 = PasswordStore {
+        name: "unit test store".to_owned(),
+        root: td.path().to_path_buf(),
+        valid_gpg_signing_keys: vec![],
+        passwords: vec![],
+        style_file: None,
+        crypto: Box::new(MockCrypto::new()),
+    };
+
+    let result = all_recipients_from_stores(Arc::new(Mutex::new(vec![s1])))?;
+
+    assert_eq!(1, result.len());
+    assert_eq!("7E068070D5EF794B00C8A9D91D108E6C07CBC406", result[0].key_id);
+
+    Ok(())
+}


### PR DESCRIPTION
Make the save_new_config function return a Result<()> instead of displaying the errorbox itself, so that the calling function doesn't close the errorbox by mistake.

Improve the edit store configuration / new store configuration dialog experience.

Write the first unit tests for the cursive application.