### PR TITLE
list of singing keys as bytes instead of strings

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -3,6 +3,7 @@ use std::cmp::PartialEq;
 use std::fs;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
+use hex::FromHex;
 
 use crate::crypto::FindSigningFingerprintStrategy;
 use std::collections::{HashMap, HashSet};
@@ -37,7 +38,7 @@ impl From<gpgme::SignatureSummary> for SignatureStatus {
 pub fn parse_signing_keys(
     password_store_signing_key: &Option<String>,
     crypto: &(dyn crate::crypto::Crypto + Send),
-) -> Result<Vec<String>> {
+) -> Result<Vec<[u8; 20]>> {
     if password_store_signing_key.is_none() {
         return Ok(vec![]);
     }
@@ -60,7 +61,11 @@ pub fn parse_signing_keys(
             )));
         }
 
-        signing_keys.push(trimmed);
+        if trimmed.len() == 40 {
+            signing_keys.push(<[u8; 20]>::from_hex(trimmed)?);
+        } else {
+            signing_keys.push(<[u8; 20]>::from_hex(&trimmed[2..])?);
+        }
     }
     Ok(signing_keys)
 }
@@ -158,7 +163,7 @@ pub struct Recipient {
     /// Machine readable identity taken from the .gpg-id file, in the form of a gpg key id
     /// (16 hex chars) or a fingerprint (40 hex chars).
     pub key_id: String,
-    /// The fingerprint of the gpg key, as 40 hex characters, not prefixed by '0x',
+    /// The fingerprint of the gpg key, 20 bytes,
     /// if the fingerprint of the key is not known, this will be None.
     pub fingerprint: Option<[u8; 20]>,
     /// The status of the key in GPG's keyring
@@ -322,7 +327,7 @@ impl Recipient {
     pub fn write_recipients_file(
         recipients: &[Recipient],
         recipients_file: &Path,
-        valid_gpg_signing_keys: &[String],
+        valid_gpg_signing_keys: &[[u8; 20]],
         crypto: &(dyn crate::crypto::Crypto + Send),
     ) -> Result<()> {
         let mut file = std::fs::OpenOptions::new()
@@ -391,7 +396,7 @@ impl Recipient {
     pub fn remove_recipient_from_file(
         s: &Recipient,
         recipients_file: &Path,
-        valid_gpg_signing_keys: &[String],
+        valid_gpg_signing_keys: &[[u8; 20]],
         crypto: &(dyn crate::crypto::Crypto + Send),
     ) -> Result<()> {
         let mut recipients: Vec<Recipient> = Recipient::all_recipients(recipients_file, crypto)?;
@@ -420,7 +425,7 @@ impl Recipient {
     pub fn add_recipient_to_file(
         recipient: &Recipient,
         recipients_file: &Path,
-        valid_gpg_signing_keys: &[String],
+        valid_gpg_signing_keys: &[[u8; 20]],
         crypto: &(dyn crate::crypto::Crypto + Send),
     ) -> Result<()> {
         let mut recipients: Vec<Recipient> = Recipient::all_recipients(recipients_file, crypto)?;

--- a/src/tests/pass.rs
+++ b/src/tests/pass.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use std::env;
 use tempfile::tempdir;
+use hex::FromHex;
 
 use crate::test_helpers::{MockCrypto, UnpackedDir};
 
@@ -1375,7 +1376,7 @@ fn test_verify_git_signature() -> Result<()> {
     let store = PasswordStore {
         name: "store_name".to_owned(),
         root: dir.dir().to_path_buf(),
-        valid_gpg_signing_keys: vec!["7E068070D5EF794B00C8A9D91D108E6C07CBC406".to_owned()],
+        valid_gpg_signing_keys: vec![<[u8; 20]>::from_hex("7E068070D5EF794B00C8A9D91D108E6C07CBC406")?],
         passwords: [].to_vec(),
         style_file: None,
         crypto: Box::new(MockCrypto::new()),
@@ -1431,7 +1432,7 @@ fn test_remove_and_commit() -> Result<()> {
     let store = PasswordStore {
         name: "store_name".to_owned(),
         root: dir.dir().to_path_buf(),
-        valid_gpg_signing_keys: vec!["7E068070D5EF794B00C8A9D91D108E6C07CBC406".to_owned()],
+        valid_gpg_signing_keys: vec![<[u8; 20]>::from_hex("7E068070D5EF794B00C8A9D91D108E6C07CBC406")?],
         passwords: [].to_vec(),
         style_file: None,
         crypto: Box::new(MockCrypto::new()),
@@ -1478,7 +1479,7 @@ fn test_verify_gpg_id_file_missing_sig_file() -> Result<()> {
     let store = PasswordStore {
         name: "store_name".to_owned(),
         root: td.path().to_path_buf(),
-        valid_gpg_signing_keys: vec!["7E068070D5EF794B00C8A9D91D108E6C07CBC406".to_owned()],
+        valid_gpg_signing_keys: vec![<[u8; 20]>::from_hex("7E068070D5EF794B00C8A9D91D108E6C07CBC406")?],
         passwords: [].to_vec(),
         style_file: None,
         crypto: Box::new(MockCrypto::new()),
@@ -1508,7 +1509,7 @@ fn test_verify_gpg_id_file() -> Result<()> {
     let store = PasswordStore {
         name: "store_name".to_owned(),
         root: td.path().to_path_buf(),
-        valid_gpg_signing_keys: vec!["7E068070D5EF794B00C8A9D91D108E6C07CBC406".to_owned()],
+        valid_gpg_signing_keys: vec![<[u8; 20]>::from_hex("7E068070D5EF794B00C8A9D91D108E6C07CBC406")?],
         passwords: [].to_vec(),
         style_file: None,
         crypto: Box::new(MockCrypto::new()),

--- a/src/tests/signature.rs
+++ b/src/tests/signature.rs
@@ -26,11 +26,11 @@ fn test_parse_signing_keys_two_keys() {
     assert_eq!(2, result.len());
     assert_eq!(
         true,
-        result.contains(&"7E068070D5EF794B00C8A9D91D108E6C07CBC406".to_owned())
+        result.contains(&<[u8; 20]>::from_hex("7E068070D5EF794B00C8A9D91D108E6C07CBC406").unwrap())
     );
     assert_eq!(
         true,
-        result.contains(&"E6A7D758338EC2EF2A8A9F4EE7E3DB4B3217482F".to_owned())
+        result.contains(&<[u8; 20]>::from_hex("E6A7D758338EC2EF2A8A9F4EE7E3DB4B3217482F").unwrap())
     );
 }
 
@@ -55,11 +55,11 @@ fn test_parse_signing_keys_two_keys_with_0x() {
     assert_eq!(2, result.len());
     assert_eq!(
         true,
-        result.contains(&"0x7E068070D5EF794B00C8A9D91D108E6C07CBC406".to_owned())
+        result.contains(&<[u8; 20]>::from_hex("7E068070D5EF794B00C8A9D91D108E6C07CBC406").unwrap())
     );
     assert_eq!(
         true,
-        result.contains(&"0xE6A7D758338EC2EF2A8A9F4EE7E3DB4B3217482F".to_owned())
+        result.contains(&<[u8; 20]>::from_hex("E6A7D758338EC2EF2A8A9F4EE7E3DB4B3217482F").unwrap())
     );
 }
 
@@ -467,7 +467,7 @@ fn write_recipients_file_one_and_signed() {
     let recipients_file = dir.path().join(".gpg-id");
     let signature_file = dir.path().join(".gpg-id.sig");
 
-    let valid_gpg_signing_keys = vec!["7E068070D5EF794B00C8A9D91D108E6C07CBC406".to_owned()];
+    let valid_gpg_signing_keys = vec![<[u8; 20]>::from_hex("7E068070D5EF794B00C8A9D91D108E6C07CBC406").unwrap()];
 
     let crypto = MockCrypto::new().with_sign_string_return("unit test sign string".to_owned());
 

--- a/src/tests/test_helpers.rs
+++ b/src/tests/test_helpers.rs
@@ -181,7 +181,7 @@ impl Crypto for MockCrypto {
     fn sign_string(
         &self,
         _: &str,
-        _: &[String],
+        _: &[[u8; 20]],
         _: &FindSigningFingerprintStrategy,
     ) -> Result<String> {
         self.sign_called.replace(true);
@@ -195,7 +195,7 @@ impl Crypto for MockCrypto {
         &self,
         _: &[u8],
         _: &[u8],
-        _: &[String],
+        _: &[[u8; 20]],
     ) -> std::result::Result<SignatureStatus, VerificationError> {
         self.verify_called.replace(true);
         Err(VerificationError::SignatureFromWrongRecipient)


### PR DESCRIPTION
when handling the list of fingerprints that are allowed to sign a store, do that as [u8; 20] instead of String, to have more typesafty