### PR TITLE
Correct translation file location

### DIFF
--- a/cursive/src/main.rs
+++ b/cursive/src/main.rs
@@ -1072,7 +1072,7 @@ fn do_delete_last_word(ui: &mut Cursive, store: PasswordStoreType) {
 fn get_translation_catalog() -> gettext::Catalog {
     let locale = locale_config::Locale::current();
 
-    let mut translation_locations = vec!["/usr/share/ripasso"];
+    let mut translation_locations = vec![];
     if let Some(path) = option_env!("TRANSLATION_INPUT_PATH") {
         translation_locations.insert(0, path);
     }
@@ -1091,6 +1091,22 @@ fn get_translation_catalog() -> gettext::Catalog {
                     if let Ok(catalog) = gettext::Catalog::parse(file) {
                         return catalog;
                     }
+                }
+            }
+        }
+    }
+
+    for preferred in locale.tags_for("messages") {
+        let langid_res: std::result::Result<LanguageIdentifier, _> = format!("{preferred}").parse();
+
+        if let Ok(langid) = langid_res {
+            let file = std::fs::File::open(format!(
+                "/usr/share/locale/{}/LC_MESSAGES/ripasso-cursive.mo",
+                langid.language
+            ));
+            if let Ok(file) = file {
+                if let Ok(catalog) = gettext::Catalog::parse(file) {
+                    return catalog;
                 }
             }
         }
@@ -1168,7 +1184,7 @@ fn get_stores(config: &config::Config, home: &Option<PathBuf>) -> Result<Vec<Pas
                 )?);
             }
         }
-    } else if final_stores.len() == 0 && home.is_some() {
+    } else if final_stores.is_empty() && home.is_some() {
         let default_path = home.clone().unwrap().join(".password_store");
         if default_path.exists() {
             final_stores.push(PasswordStore::new(
@@ -1214,7 +1230,7 @@ fn validate_stores_config(settings: &config::Config, home: &Option<PathBuf>) -> 
                 }
             }
         }
-    } else if incomplete_stores.len() == 0 && home.is_some() {
+    } else if incomplete_stores.is_empty() && home.is_some() {
         incomplete_stores.push(home.clone().unwrap().join(".password_store"));
     }
 


### PR DESCRIPTION
Use /usr/share/locale/{}/LC_MESSAGES/ripasso-cursive.mo as a path for the compiled translation files instead of /usr/share/ripasso .