### PR TITLE
Zeroize Secrets (Cursive and Lib)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,6 +2816,7 @@ dependencies = [
  "toml 0.8.8",
  "totp-rs",
  "whoami",
+ "zeroize",
 ]
 
 [[package]]
@@ -2837,6 +2838,7 @@ dependencies = [
  "terminal_size",
  "toml 0.8.8",
  "unic-langid",
+ "zeroize",
 ]
 
 [[package]]
@@ -4204,6 +4206,26 @@ name = "zerocopy-derive"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ base64 = "0.21.4"
 sha2 = "0.10.8"
 sha1 = "0.10.6"
 hmac = "0.12.1"
+zeroize = { version = "1.7.0", features = ["zeroize_derive", "alloc"] }
 
 [dependencies.config]
 version = "0.11.0"

--- a/cursive/Cargo.toml
+++ b/cursive/Cargo.toml
@@ -21,6 +21,7 @@ lazy_static = "1.4.0"
 toml = "0.8.2"
 terminal_size = "0.3.0"
 hex = "0.4.3"
+zeroize = { version = "1.7.0", features = ["zeroize_derive", "alloc"] }
 
 [dependencies.config]
 version = "0.11.0"

--- a/cursive/src/helpers.rs
+++ b/cursive/src/helpers.rs
@@ -52,7 +52,7 @@ pub fn errorbox(ui: &mut Cursive, err: &pass::Error) {
 }
 
 /// Copies content to the clipboard.
-pub fn set_clipboard(content: String) -> Result<()> {
+pub fn set_clipboard(content: &String) -> Result<()> {
     Ok(CLIPBOARD.lock().unwrap().set_text(content)?)
 }
 

--- a/cursive/src/tests/main.rs
+++ b/cursive/src/tests/main.rs
@@ -193,7 +193,6 @@ fn substr_overlong() {
 
 #[test]
 fn create_label_basic() {
-
     // TODO: Fix this test so that time zones don't mess with it.
 
     let p = pass::PasswordEntry::new(

--- a/cursive/src/tests/main.rs
+++ b/cursive/src/tests/main.rs
@@ -193,6 +193,9 @@ fn substr_overlong() {
 
 #[test]
 fn create_label_basic() {
+
+    // TODO: Fix this test so that time zones don't mess with it.
+
     let p = pass::PasswordEntry::new(
         &PathBuf::from("/tmp/"),
         &PathBuf::from("file.gpg"),

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -26,7 +26,7 @@ use sequoia_openpgp::{
     types::{RevocationStatus, SymmetricAlgorithm},
     Cert, KeyHandle,
 };
-use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+use zeroize::Zeroize;
 
 pub use crate::error::{Error, Result};
 use crate::{

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -26,6 +26,7 @@ use sequoia_openpgp::{
     types::{RevocationStatus, SymmetricAlgorithm},
     Cert, KeyHandle,
 };
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 pub use crate::error::{Error, Result};
 use crate::{
@@ -227,7 +228,9 @@ impl Crypto for GpgMe {
         let mut ctx = gpgme::Context::from_protocol(gpgme::Protocol::OpenPgp)?;
         let mut output = Vec::new();
         ctx.decrypt(ciphertext, &mut output)?;
-        Ok(String::from_utf8(output)?)
+        let result = String::from_utf8(output.to_vec())?;
+        output.zeroize();
+        Ok(result)
     }
 
     fn encrypt_string(&self, plaintext: &str, recipients: &[Recipient]) -> Result<Vec<u8>> {
@@ -249,7 +252,6 @@ impl Crypto for GpgMe {
             &mut output,
             gpgme::EncryptFlags::NO_COMPRESS,
         )?;
-
         Ok(output)
     }
 
@@ -756,8 +758,9 @@ impl Crypto for Sequoia {
 
             // Decrypt the data.
             std::io::copy(&mut decryptor, &mut sink).unwrap();
-
-            Ok(std::str::from_utf8(&sink).unwrap().to_owned())
+            let result = std::str::from_utf8(&sink).unwrap().to_owned();
+            sink.zeroize();
+            Ok(result)
         } else {
             // Make a helper that that feeds the recipient's secret key to the
             // decryptor.
@@ -776,8 +779,9 @@ impl Crypto for Sequoia {
 
             // Decrypt the data.
             std::io::copy(&mut decryptor, &mut sink)?;
-
-            Ok(std::str::from_utf8(&sink)?.to_owned())
+            let result = std::str::from_utf8(&sink)?.to_owned();
+            sink.zeroize();
+            Ok(result)
         }
     }
 

--- a/src/pass.rs
+++ b/src/pass.rs
@@ -26,7 +26,7 @@ use std::{
 
 use chrono::prelude::*;
 use totp_rs::TOTP;
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::Zeroize;
 
 use crate::{
     crypto::{Crypto, CryptoImpl, GpgMe, Sequoia, VerificationError},

--- a/src/pass.rs
+++ b/src/pass.rs
@@ -1051,7 +1051,7 @@ impl PasswordEntry {
     }
 
     /// All calls to this function must be followed by secret.zeroize()
-    fn update_internal(&self, secret: &String, store: &PasswordStore) -> Result<()> {
+    fn update_internal(&self, secret: &str, store: &PasswordStore) -> Result<()> {
         if !store.valid_gpg_signing_keys.is_empty() {
             store.verify_gpg_id_files()?;
         }

--- a/src/pass.rs
+++ b/src/pass.rs
@@ -1019,7 +1019,7 @@ impl PasswordEntry {
     /// Returns an `Err` if the decryption fails
     pub fn password(&self, store: &PasswordStore) -> Result<String> {
         let mut secret = self.secret(store)?;
-        let password: String= secret.split('\n').take(1).collect();
+        let password: String = secret.split('\n').take(1).collect();
         secret.zeroize();
         Ok(password)
     }

--- a/src/tests/pass.rs
+++ b/src/tests/pass.rs
@@ -1184,9 +1184,10 @@ fn decrypt_password_multiline() -> Result<()> {
         user_home: None,
     };
 
-    let res = pe.password(&store).unwrap();
+    let mut res = pe.password(&store).unwrap();
 
     assert_eq!("row one", res);
+    res.zeroize();
 
     Ok(())
 }


### PR DESCRIPTION
Summary of changes:
- Added zeroize crate to both library and cursive implementation
- Modified secret strings such that they are zeroized after use
- Discovered a failing test due to timezones (EST) that should be changed to leverage the current local timestamp
- (Only left a TODO comment for the above as fixing it is beyond the scope of this PR)

GTK implementation is left as a TODO because property values could be either secrets or proper values, so handling was arbitrary.

One thing of note, there is a comment asking whether something should be calling `password()` instead of `secret()`, this may be me misunderstanding the file structure since I didn't look too closely at it, but my understanding is that the first line of an entry is the password.

Fixes #207 for library and Cursive, GTK is left for later.