### PR TITLE
Update README.md about installation on Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cargo build -p ripasso-gtk
 
 TUI version
 ```
-paru install ripasso-cursive
+pacman -S ripasso
 ```
 
 ### Fedora


### PR DESCRIPTION
I packaged `ripasso` in the official repositories: https://archlinux.org/packages/extra/x86_64/ripasso/
