### PR TITLE
Relax requirement for 128 bit totp secrets

### DIFF
--- a/src/pass.rs
+++ b/src/pass.rs
@@ -1041,7 +1041,9 @@ impl PasswordEntry {
                 }
                 end_pos
             };
-            let totp = TOTP::from_url(&secret[start_pos..end_pos])?;
+            // Use unchecked for sites like Discord, Github that still use 80
+            // bit secrets. https://github.com/constantoine/totp-rs/issues/46
+            let totp = TOTP::from_url_unchecked(&secret[start_pos..end_pos])?;
             secret.zeroize();
             Ok(totp.generate_current()?)
         } else {


### PR DESCRIPTION
totp-rs is strictly RFC6238 compliant. This is a good thing, but the reality is many sites/apps are still using 80 bit secrets for TOTP. These include Github, Discord, Paypal, among others. The author of totp-rs added a function `from_url_unchecked` to address this in this issue: https://github.com/constantoine/totp-rs/issues/46. I suggest we use it here so that ripasso can be used practically for totp.