### PR TITLE
fixes broken scrolling on pageup and pagedown

### DIFF
--- a/cursive/src/main.rs
+++ b/cursive/src/main.rs
@@ -106,10 +106,10 @@ fn up(ui: &mut Cursive) {
 }
 
 fn page_down(ui: &mut Cursive) {
-    let mut l = ui
-        .find_name::<SelectView<pass::PasswordEntry>>("results")
-        .unwrap();
-    l.select_down(screen_height(ui));
+    let rows = screen_height(&ui);
+    ui.call_on_name("results", |l: &mut SelectView<pass::PasswordEntry>| {
+        l.select_down(rows);
+    });
     ui.call_on_name(
         "scroll_results",
         |l: &mut ScrollView<ResizedView<NamedView<SelectView<pass::PasswordEntry>>>>| {
@@ -119,10 +119,10 @@ fn page_down(ui: &mut Cursive) {
 }
 
 fn page_up(ui: &mut Cursive) {
-    let mut l = ui
-        .find_name::<SelectView<pass::PasswordEntry>>("results")
-        .unwrap();
-    l.select_up(screen_height(ui));
+    let rows = screen_height(&ui);
+    ui.call_on_name("results", |l: &mut SelectView<pass::PasswordEntry>| {
+        l.select_up(rows);
+    });
     ui.call_on_name(
         "scroll_results",
         |l: &mut ScrollView<ResizedView<NamedView<SelectView<pass::PasswordEntry>>>>| {

--- a/cursive/src/main.rs
+++ b/cursive/src/main.rs
@@ -106,7 +106,7 @@ fn up(ui: &mut Cursive) {
 }
 
 fn page_down(ui: &mut Cursive) {
-    let rows = screen_height(&ui);
+    let rows = screen_height(&ui) - 6;
     ui.call_on_name("results", |l: &mut SelectView<pass::PasswordEntry>| {
         l.select_down(rows);
     });
@@ -119,7 +119,7 @@ fn page_down(ui: &mut Cursive) {
 }
 
 fn page_up(ui: &mut Cursive) {
-    let rows = screen_height(&ui);
+    let rows = screen_height(&ui) - 6;
     ui.call_on_name("results", |l: &mut SelectView<pass::PasswordEntry>| {
         l.select_up(rows);
     });

--- a/cursive/src/main.rs
+++ b/cursive/src/main.rs
@@ -106,7 +106,7 @@ fn up(ui: &mut Cursive) {
 }
 
 fn page_down(ui: &mut Cursive) {
-    let rows = screen_height(&ui) - 6;
+    let rows = screen_height(&ui) - 7;
     ui.call_on_name("results", |l: &mut SelectView<pass::PasswordEntry>| {
         l.select_down(rows);
     });
@@ -119,7 +119,7 @@ fn page_down(ui: &mut Cursive) {
 }
 
 fn page_up(ui: &mut Cursive) {
-    let rows = screen_height(&ui) - 6;
+    let rows = screen_height(&ui) - 7;
     ui.call_on_name("results", |l: &mut SelectView<pass::PasswordEntry>| {
         l.select_up(rows);
     });


### PR DESCRIPTION
Currently, pressing PageUp and PageDown moves the selection, but the visible area always scrolls to the top of the list. This PR fixes the behavior so that the scrolling now correctly follows the selection.