### PR TITLE
check git config in repo before checking global git config

### DIFF
--- a/src/pass.rs
+++ b/src/pass.rs
@@ -422,6 +422,15 @@ impl PasswordStore {
             return true;
         }
 
+        if let Ok(repo) = self.repo() {
+            if let Ok(config) = repo.config() {
+                let user_name = config.get_string("user.name");
+                if user_name.is_ok() {
+                    return true;
+                }
+            }
+        }
+
         match git2::Config::open_default() {
             Err(_) => false,
             Ok(config) => {


### PR DESCRIPTION
Fixes: https://github.com/cortex/ripasso/issues/366

This PR adds a git configuration check in the local repository before checking global git configuration, to allow the user to only have a local git configuration and no global git config.