### PR TITLE
Added flake.nix default.nix for building on nix systems

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,12 @@
+{
+  rustPlatform,
+  glib,
+  pkg-config,
+}:
+rustPlatform.buildRustPackage {
+  name = "ripasso";
+  src = ./.;
+  buildInputs = [ glib ];
+  nativeBuildInputs = [ pkg-config ];
+  cargoHash = "sha256-UMhQgijZuZW2O/0Jk5Zn8P368KnDWZRXj5e1nDG40Gw=";
+} 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "Rust flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs, ... }@inputs:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+
+      clangLibPath = "${pkgs.libclang.lib}/lib";
+      opensslDev = pkgs.openssl.dev;
+      opensslOut = pkgs.openssl.out;
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        packages = with pkgs; [
+          rustc
+          cargo
+          clang
+          libclang
+          openssl
+          pkg-config
+          libgpg-error
+          nettle
+          gpgme
+          ripasso-cursive
+        ];
+
+        shellHook = ''
+          # Clang
+          export LIBCLANG_PATH=${clangLibPath}
+          export LD_LIBRARY_PATH=${clangLibPath}:${opensslOut}/lib:$LD_LIBRARY_PATH
+
+          # OpenSSL
+          export OPENSSL_NO_VENDOR=1
+          export OPENSSL_LIB_DIR=${opensslOut}/lib
+          export OPENSSL_INCLUDE_DIR=${opensslDev}/include
+
+          echo "  LIBCLANG_PATH         = $LIBCLANG_PATH"
+          echo "  LD_LIBRARY_PATH       = $LD_LIBRARY_PATH"
+          echo "  OPENSSL_LIB_DIR       = $OPENSSL_LIB_DIR"
+          echo "  OPENSSL_INCLUDE_DIR   = $OPENSSL_INCLUDE_DIR"
+        '';
+      };
+    };
+}


### PR DESCRIPTION
I created a flake.nix and default.nix to allow for building in Nix systems. To build run "nix develop" in the ripasso directory this will create a flake.nix file for you. After that run "cargo build -p ripasso-cursive" to create your binary then run "./target/debug/ripasso-cursive" to run the binary.